### PR TITLE
Fix plugin version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,4 +73,4 @@ All CSS is contained in `assets/css/header.css` with WDM-prefixed classes for un
 
 ## Version
 
-1.0.0 - Initial release with Grey Bull Rescue branding
+1.3.0 - Initial release with Grey Bull Rescue branding


### PR DESCRIPTION
## Summary
- bump plugin version in README to reflect version 1.3.0

## Testing
- `php -l wdm-custom-header.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68666b0e92788320ae16e13bcaa6893b