### PR TITLE
Add mobile overlay menu to header

### DIFF
--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -308,6 +308,107 @@
   transform: rotate(-45deg);
 }
 
+/* Mobile overlay menu */
+.wdm-mobile-menu-overlay {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #ffffff;
+  overflow-y: auto;
+  z-index: 2000;
+  padding: 80px 20px 20px;
+  font-family: inherit;
+}
+
+.wdm-mobile-menu-overlay.active {
+  display: block;
+}
+
+.wdm-mobile-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.wdm-mobile-menu-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.wdm-mobile-menu-item {
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.mobile-menu-toggle,
+.mobile-menu-link {
+  width: 100%;
+  padding: 15px 0;
+  background: none;
+  border: none;
+  color: #212529;
+  font-size: 18px;
+  font-weight: 600;
+  text-align: left;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.mobile-menu-icon {
+  border: solid #212529;
+  border-width: 0 2px 2px 0;
+  display: inline-block;
+  padding: 4px;
+  transform: rotate(45deg);
+  margin-left: 8px;
+  transition: transform 0.2s ease;
+}
+
+.mobile-menu-toggle[aria-expanded="true"] .mobile-menu-icon {
+  transform: rotate(-135deg);
+}
+
+.mobile-menu-dropdown {
+  display: none;
+  padding: 0 0 10px 15px;
+}
+
+.mobile-menu-dropdown.active {
+  display: block;
+}
+
+.mobile-submenu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.mobile-submenu-item {
+  margin-bottom: 8px;
+}
+
+.mobile-submenu-link {
+  display: block;
+  padding: 8px 0;
+  color: #6c757d;
+  text-decoration: none;
+  font-size: 16px;
+}
+
+.mobile-submenu-link:hover {
+  color: #dc3545;
+}
+
+@media (min-width: 769px) {
+  .wdm-mobile-menu-overlay {
+    display: none !important;
+  }
+}
+
 /* Main Navigation */
 .Header-nav-main {
   background: #f8f9fa;

--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -72,10 +72,25 @@
   function initializeMobileMenu(header) {
     const mobileToggle = header.querySelector(".wdm-hamburger-btn");
     const nav = header.querySelector(".Nav-expandable-wrap");
+    const overlay = document.getElementById("wdm-mobile-menu");
 
-    if (mobileToggle && nav) {
+    if (mobileToggle) {
       mobileToggle.addEventListener("click", function () {
-        toggleMobileMenu(mobileToggle, nav);
+        toggleMobileMenu(mobileToggle, nav, overlay, header);
+      });
+    }
+
+    if (overlay) {
+      overlay.querySelectorAll(".mobile-menu-toggle").forEach(function (btn) {
+        const id = btn.getAttribute("data-expands");
+        const panel = overlay.querySelector("#" + id);
+        btn.addEventListener("click", function () {
+          const expanded = btn.getAttribute("aria-expanded") === "true";
+          btn.setAttribute("aria-expanded", !expanded);
+          if (panel) {
+            panel.classList.toggle("active");
+          }
+        });
       });
     }
   }
@@ -83,35 +98,38 @@
   /**
    * Toggle mobile menu
    */
-  function toggleMobileMenu(toggle, nav) {
-    const isActive = nav.classList.contains("active");
-    const header = toggle.closest(".wdm-main-header");
+  function toggleMobileMenu(toggle, nav, overlay, header) {
+    const isMobile = window.innerWidth <= 768 && overlay;
 
-    if (isActive) {
-      nav.classList.remove("active");
-      toggle.classList.remove("active");
-
-      // Close all dropdowns when closing mobile menu
-      const navItems = nav.querySelectorAll(".Nav-item");
-      navItems.forEach(function (item) {
-        item.classList.remove("active");
-        const dropdown = item.querySelector(".Nav-dropdown, .Nav-megaDropdown");
-        if (dropdown) {
-          dropdown.classList.remove("active");
-        }
-      });
-
-      // Remove nav-open class from header
-      if (header) {
+    if (isMobile) {
+      const open = overlay.classList.contains("active");
+      if (open) {
+        overlay.classList.remove("active");
+        toggle.classList.remove("active");
         header.classList.remove("nav-open");
-      }
-    } else {
-      nav.classList.add("active");
-      toggle.classList.add("active");
-
-      // Add nav-open class to header
-      if (header) {
+      } else {
+        overlay.classList.add("active");
+        toggle.classList.add("active");
         header.classList.add("nav-open");
+      }
+      return;
+    }
+
+    const isActive = nav && nav.classList.contains("active");
+
+    if (nav) {
+      if (isActive) {
+        nav.classList.remove("active");
+        toggle.classList.remove("active");
+        if (header) {
+          header.classList.remove("nav-open");
+        }
+      } else {
+        nav.classList.add("active");
+        toggle.classList.add("active");
+        if (header) {
+          header.classList.add("nav-open");
+        }
       }
     }
   }
@@ -120,10 +138,19 @@
    * Initialize outside click functionality
    */
   function initializeOutsideClick(header) {
+    const overlay = document.getElementById("wdm-mobile-menu");
     document.addEventListener("click", function (e) {
-      // Check if click is outside header
-      if (!header.contains(e.target)) {
+      const clickInsideHeader = header.contains(e.target);
+      const clickInsideOverlay = overlay && overlay.contains(e.target);
+
+      if (!clickInsideHeader && !clickInsideOverlay) {
         closeAllDropdowns(header);
+        if (overlay && overlay.classList.contains("active")) {
+          overlay.classList.remove("active");
+          const toggle = header.querySelector(".wdm-hamburger-btn");
+          if (toggle) toggle.classList.remove("active");
+          header.classList.remove("nav-open");
+        }
       }
     });
   }
@@ -176,10 +203,16 @@
         // Close mobile menu
         const mobileToggle = header.querySelector(".wdm-hamburger-btn");
         const nav = header.querySelector(".Nav-expandable-wrap");
+        const overlay = document.getElementById("wdm-mobile-menu");
 
-        if (mobileToggle && nav && nav.classList.contains("active")) {
+        if (overlay && overlay.classList.contains("active")) {
+          overlay.classList.remove("active");
+          if (mobileToggle) mobileToggle.classList.remove("active");
+          header.classList.remove("nav-open");
+        } else if (mobileToggle && nav && nav.classList.contains("active")) {
           mobileToggle.classList.remove("active");
           nav.classList.remove("active");
+          header.classList.remove("nav-open");
         }
       }
     }

--- a/templates/header.php
+++ b/templates/header.php
@@ -251,3 +251,41 @@ $show_search = $options['show_search'] ?? false;
     </div>
   </div>
 </header>
+
+<?php if (!empty($menu_items)) : ?>
+  <div class="wdm-mobile-menu-overlay" id="wdm-mobile-menu" aria-hidden="true">
+    <nav class="wdm-mobile-nav" aria-label="Mobile">
+      <ul class="wdm-mobile-menu-list" role="list">
+        <?php foreach ($menu_items as $item) :
+          $text = esc_html($item['text'] ?? '');
+          $url = esc_url($item['url'] ?? '#');
+          $submenu = $item['submenu'] ?? [];
+          $has_dropdown = !empty($submenu);
+          $dropdown_id = sanitize_title(($item['text'] ?? uniqid('mobile_')) . '-mobile');
+        ?>
+          <li class="wdm-mobile-menu-item <?php echo $has_dropdown ? 'has-dropdown' : ''; ?>">
+            <?php if ($has_dropdown) : ?>
+              <button class="mobile-menu-toggle" type="button" data-expands="<?php echo esc_attr($dropdown_id); ?>">
+                <?php echo $text; ?>
+                <span class="mobile-menu-icon" aria-hidden="true"></span>
+              </button>
+              <div class="mobile-menu-dropdown" id="<?php echo esc_attr($dropdown_id); ?>" aria-hidden="true">
+                <ul class="mobile-submenu" role="list">
+                  <?php foreach ($submenu as $sub) : ?>
+                    <li class="mobile-submenu-item">
+                      <a href="<?php echo esc_url($sub['url'] ?? '#'); ?>" class="mobile-submenu-link">
+                        <?php echo esc_html($sub['text'] ?? ''); ?>
+                      </a>
+                    </li>
+                  <?php endforeach; ?>
+                </ul>
+              </div>
+            <?php else : ?>
+              <a href="<?php echo $url; ?>" class="mobile-menu-link"><?php echo $text; ?></a>
+            <?php endif; ?>
+          </li>
+        <?php endforeach; ?>
+      </ul>
+    </nav>
+  </div>
+<?php endif; ?>


### PR DESCRIPTION
## Summary
- implement a mobile overlay version of the mega menu
- style overlay menu in header.css to match existing design
- update header.js to toggle overlay and close on outside click or Esc
- update header template with mobile menu markup

## Testing
- `php -l templates/header.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68666c7a560083209e38f324690b5fcf